### PR TITLE
added component 03-calendar

### DIFF
--- a/05-lection3/03-calendar/calendar.css
+++ b/05-lection3/03-calendar/calendar.css
@@ -1,0 +1,63 @@
+.calendar {
+    border: 1px solid var(--grey-3);
+    border-radius: 8px;
+    padding: 28px 26px 32px;
+}
+
+.calendar__title {
+    font-family: 'Inter', sans-serif;
+    font-weight: 600;
+    font-size: 20px;
+    line-height: 24px;
+    color: #334D6E;
+    margin: 0 0 16px 0;
+    text-align: center;
+}
+
+.calendar__wrapper {
+    position: relative;
+    padding-top: 89%;
+}
+
+.calendar__inner {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    grid-template-rows: 1fr 8px repeat(5, 1fr);
+    place-items: stretch;
+}
+
+.calendar__item {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 20px;
+}
+
+.calendar__item_day {
+    font-family: 'Inter';
+    color: #90A0B7;
+}
+
+.calendar__item_number {
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 20px;
+    color: #334D6E;
+}
+
+.calendar__item_in-range {
+    background: rgba(160, 177, 245, 0.2);
+}
+
+.calendar__item_edge-range {
+    background: var(--primary);
+    color: #fff;
+}

--- a/05-lection3/03-calendar/index.html
+++ b/05-lection3/03-calendar/index.html
@@ -5,8 +5,72 @@
         <link rel="stylesheet" href="../../assets/css/main.css">
         <link rel="stylesheet" href="./calendar.css">
         <title>Calendar</title>
+        <style>
+            .container-calendar {
+                width: 304px;
+                margin-left: 120px;
+                margin-top: 80px;
+            }
+        </style>
     </head>
     <body>
-
+        <div class="container-calendar">
+            <div class="calendar">
+                <h3 class="calendar__title">October 2019</h3>
+                <div class="calendar__wrapper">
+                    <div class="calendar__inner">
+                        <span class="calendar__item calendar__item_day">Mon</span>
+                        <span class="calendar__item calendar__item_day">Tue</span>
+                        <span class="calendar__item calendar__item_day">Wed</span>
+                        <span class="calendar__item calendar__item_day">Thu</span>
+                        <span class="calendar__item calendar__item_day">Fri</span>
+                        <span class="calendar__item calendar__item_day">Sat</span>
+                        <span class="calendar__item calendar__item_day">Sun</span>
+                        <span class="calendar__item calendar__item_number"></span>
+                        <span class="calendar__item calendar__item_number"></span>
+                        <span class="calendar__item calendar__item_number"></span>
+                        <span class="calendar__item calendar__item_number"></span>
+                        <span class="calendar__item calendar__item_number"></span>
+                        <span class="calendar__item calendar__item_number"></span>
+                        <span class="calendar__item calendar__item_number"></span>
+                        <span class="calendar__item calendar__item_number"></span>
+                        <span class="calendar__item calendar__item_number"></span>
+                        <span class="calendar__item calendar__item_number"></span>
+                        <span class="calendar__item calendar__item_number"></span>
+                        <span class="calendar__item calendar__item_number">1</span>
+                        <span class="calendar__item calendar__item_number">2</span>
+                        <span class="calendar__item calendar__item_number">3</span>
+                        <span class="calendar__item calendar__item_number">4</span>
+                        <span class="calendar__item calendar__item_number">5</span>
+                        <span class="calendar__item calendar__item_number">6</span>
+                        <span class="calendar__item calendar__item_number">7</span>
+                        <span class="calendar__item calendar__item_number">8</span>
+                        <span class="calendar__item calendar__item_number">9</span>
+                        <span class="calendar__item calendar__item_number">10</span>
+                        <span class="calendar__item calendar__item_number">11</span>
+                        <span class="calendar__item calendar__item_number">12</span>
+                        <span class="calendar__item calendar__item_number">13</span>
+                        <span class="calendar__item calendar__item_number">14</span>
+                        <span class="calendar__item calendar__item_number">15</span>
+                        <span class="calendar__item calendar__item_number">16</span>
+                        <span class="calendar__item calendar__item_number">17</span>
+                        <span class="calendar__item calendar__item_number calendar__item_edge-range">18</span>
+                        <span class="calendar__item calendar__item_number calendar__item_in-range">19</span>
+                        <span class="calendar__item calendar__item_number calendar__item_in-range">20</span>
+                        <span class="calendar__item calendar__item_number calendar__item_in-range">21</span>
+                        <span class="calendar__item calendar__item_number calendar__item_in-range">22</span>
+                        <span class="calendar__item calendar__item_number calendar__item_edge-range">23</span>
+                        <span class="calendar__item calendar__item_number">24</span>
+                        <span class="calendar__item calendar__item_number">25</span>
+                        <span class="calendar__item calendar__item_number">26</span>
+                        <span class="calendar__item calendar__item_number">27</span>
+                        <span class="calendar__item calendar__item_number">28</span>
+                        <span class="calendar__item calendar__item_number">29</span>
+                        <span class="calendar__item calendar__item_number">30</span>
+                        <span class="calendar__item calendar__item_number">31</span>
+                    </div>
+                </div>
+            </div>
+        </div>
     </body>
 </html>

--- a/assets/fonts/fonts.css
+++ b/assets/fonts/fonts.css
@@ -1,2 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+@font-face {
+  font-family: 'Source Sans Pro';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(https://cdn.jsdelivr.net/fontsource/fonts/source-sans-pro@latest/latin-400-normal.woff2) format('woff2'), url(https://cdn.jsdelivr.net/fontsource/fonts/source-sans-pro@latest/latin-400-normal.woff) format('woff');
+}


### PR DESCRIPTION
В .calendar__wrapper задал padding-top: 89%;, поскольку по макету сам календарь не совсем квадратный, соотношение сторон там именно 1:0.89. Добавил пустую вторую строку высотой 8px, т.к. по макету между строкой дней недели и следующей за ней строкой чисел расстояние на 8px больше, чем просто между строками чисел.